### PR TITLE
Grant execute permission to current user for build_detect_platform

### DIFF
--- a/config/aqx/aqx.compile
+++ b/config/aqx/aqx.compile
@@ -2,5 +2,6 @@
 # this file contains all commands to compile and install the daemon
 
 ./autogen.sh
+chmod u+x src/leveldb/build_detect_platform
 ./configure
 make install


### PR DESCRIPTION
Running install.sh for AQX was failing on building LevelDB. As can be seen in the attached screenshot, there are a lack of permissions to execute build_detect_platform. Looking at the .compile files for other coins, it appears this is a known issue and execute permissions are granted there. 

![error](https://user-images.githubusercontent.com/985334/46015643-cf4c8900-c0a0-11e8-8bd2-5a8f4b4da2de.png)
